### PR TITLE
disambiguate acquisitions labels

### DIFF
--- a/app/main.organize.controller.js
+++ b/app/main.organize.controller.js
@@ -91,21 +91,36 @@ function organizeCtrl(steps, organizerStore){
           children: {},
           sessionTimestamp: dicom.sessionTimestamp,
           patientID: dicom.patientID,
-          parent: project
+          parent: project,
+          labels: {},
+          acquisitionsUID: {}
         };
       }
-      let acquisitions = sessions[dicom.sessionUID].children;
-      if (!acquisitions.hasOwnProperty(dicom.acquisitionUID)) {
-        acquisitions[dicom.acquisitionUID] = {
+      const acquisitions = sessions[dicom.sessionUID].children;
+      const acquisitionsUID = sessions[dicom.sessionUID].acquisitionsUID;
+      const labels = sessions[dicom.sessionUID].labels;
+      if (!acquisitionsUID.hasOwnProperty(dicom.acquisitionUID)) {
+        if (acquisitions.hasOwnProperty(dicom.acquisitionLabel)) {
+          const labelCount = labels[dicom.acquisitionLabel];
+          labels[dicom.acquisitionLabel] += 1;
+          dicom.acquisitionLabel = dicom.acquisitionLabel + ' ' + labelCount;
+        } else {
+          labels[dicom.acquisitionLabel] = 1;
+        }
+        acquisitions[dicom.acquisitionLabel] = {
           filepaths: [],
           acquisitionLabel: dicom.acquisitionLabel,
+          acquisitionUID: dicom.acquisitionUID,
           acquisitionTimestamp: dicom.acquisitionTimestamp,
           count: 0,
           size: 0,
           parent: sessions[dicom.sessionUID]
         };
+        acquisitionsUID[dicom.acquisitionUID] = dicom.acquisitionLabel;
+      } else {
+        dicom.acquisitionLabel = acquisitionsUID[dicom.acquisitionUID];
       }
-      let acquisition = acquisitions[dicom.acquisitionUID];
+      let acquisition = acquisitions[dicom.acquisitionLabel];
       acquisition.count += 1;
       acquisition.size += dicom.size;
       acquisition.filepaths.push(dicom.path);

--- a/app/services/projects.js
+++ b/app/services/projects.js
@@ -55,9 +55,9 @@ function projectsService(fileSystemQueues) {
           waitFor: projectDir_
         });
         allPromises.push(sessionDir_);
-        Object.keys(session.children).forEach((acquisitionUID) => {
-          const acqPath = sessionPath + '/' + acquisitionUID;
-          const acquisition = session.children[acquisitionUID];
+        Object.keys(session.children).forEach((acquisitionLabel) => {
+          const acqPath = sessionPath + '/' + acquisitionLabel;
+          const acquisition = session.children[acquisitionLabel];
           if (acquisition.state !== 'checked' && acquisition.state !== 'indeterminate'){
             return;
           }
@@ -67,7 +67,7 @@ function projectsService(fileSystemQueues) {
             waitFor: sessionDir_
           });
           const archivePromise = createZip(acquisition.filepaths);
-          const zipPath = acqPath + '/' + acquisitionUID + '.zip';
+          const zipPath = acqPath + '/' + acquisition.acquisitionUID + '.zip';
           allPromises.push(fileSystemQueues.append({
             operation: 'write',
             path: zipPath,


### PR DESCRIPTION
closes #52
We modify acquisition labels so that within a session acquisitions with
different uids have different labels