### PR TITLE
Add config and persistence for upload URL.

### DIFF
--- a/app/main.upload.controller.js
+++ b/app/main.upload.controller.js
@@ -5,17 +5,18 @@ const app = angular.module('app');
 
 app.controller('uploadCtrl', uploadCtrl);
 
-uploadCtrl.$inject = ['$scope', '$rootScope', '$timeout', 'organizerStore', 'organizerUpload'];
+uploadCtrl.$inject = ['$scope', '$rootScope', '$timeout', 'organizerStore', 'organizerUpload', 'config'];
 
 // jshint maxparams:6
-function uploadCtrl($scope, $rootScope, $timeout, organizerStore, organizerUpload){
+function uploadCtrl($scope, $rootScope, $timeout, organizerStore, organizerUpload, config){
   /*jshint validthis: true */
   const vm = this;
   vm.projectWarning = '';
   vm.asRoot = false;
-  vm.url = '';
+  vm.url = config.getItem('url') || '';
   vm.loadGroups = function loadGroups() {
     if (vm.url && vm.apiKey){
+      config.setItem('url', vm.url);
       organizerUpload.loadGroups(vm.url, vm.apiKey, vm.asRoot).then(function(groups){
         console.log(groups);
         vm.groups = JSON.parse(groups);

--- a/app/renderer.js
+++ b/app/renderer.js
@@ -17,6 +17,7 @@ const app = angular.module('app', [require('angular-ui-router')]);
 //const ipc  = require('electron').ipcRenderer;
 
 require('./filters/objLength.js');
+require('./services/config.js');
 require('./services/dicom.js');
 require('./services/steps.js');
 require('./services/store.js');

--- a/app/services/config.js
+++ b/app/services/config.js
@@ -1,0 +1,48 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const angular = require('angular');
+const process = require('process');
+
+angular.module('app').factory('config', config);
+
+config.$inject = [];
+
+const configPath = path.join(process.env.USER_DATA_PATH, 'user.json');
+
+function config() {
+  let config;
+
+  if (fs.existsSync(configPath)) {
+    try {
+      config = JSON.parse(fs.readFileSync(configPath));
+    } catch (e) {
+      console.error(`Error when loading config: ${e.stack}`);
+    }
+  }
+  if (!config) {
+    config = {};
+  }
+
+  // implements some methods from the Storage Web API
+  return {
+    getItem(key) {
+      return config[key];
+    },
+
+    setItem(key, value) {
+      config[key] = value;
+      return new Promise(function(resolve) {
+        // Running writing to file async. We don't really care if it fails.
+        fs.writeFile(
+          configPath,
+          JSON.stringify(config, null, 2),
+          // We write the file in a restricted way so we can potentially add
+          // credentials to it later.
+          {mode: '600'},
+          resolve
+        );
+      });
+    }
+  };
+}

--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ const ipc = require('electron').ipcMain;
 const dialog = require('electron').dialog;
 app.commandLine.appendSwitch('js-flags','--max_old_space_size=4096');
 
-
+process.env.USER_DATA_PATH = app.getPath('userData');
 
 ipc.on('open-file-dialog', function (event, arg) {
   const window = BrowserWindow.fromWebContents(event.sender);


### PR DESCRIPTION
decided to go for `process.env.USER_DATA_PATH` to simplify startup for the module, and because it doesn't seem to change very often. it might be preferable to put this in `~/.scitran-organizer/user.json` sooner rather than later, but `app.getPath('userData')` seemed like it could potentially be more idiomatic (although certainly more difficult to track down where the data is as it varies per platform).