### PR TITLE
Ensure we also send up acquisition UID.

### DIFF
--- a/app/main.upload.controller.js
+++ b/app/main.upload.controller.js
@@ -94,6 +94,7 @@ function uploadCtrl($scope, $rootScope, $timeout, organizerStore, organizerUploa
           const filename = acquisitionUID + '.zip';
           const metadataAcq = {
             acquisition: {
+              'uid': acquisition.acquisitionUID,
               'label': acquisition.acquisitionLabel,
               'timestamp': acquisition.acquisitionTimestamp.ts,
               'files': [{


### PR DESCRIPTION
This PR is untested.

This change adds the acquisition UID to the upload body, mostly useful for my upsert behavior living in a branch, but this also avoids throwing away some nice info.

I wonder if an analogous change to session should be done (upload `sessionUID` as `session.uid`), but that change would also only be helpful for my upsert-like code.